### PR TITLE
Feature/remove player usecase

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -27,3 +27,11 @@ We can now retrieve all the registered players::
 And we should get the following::
 
     ['Alice', 'Bob']
+
+We can also remove players that we no longer want in the roachcase::
+
+    roachcase.remove_player("Alice")
+
+This will remove the player "Alice" so the only player left in the roachcase is
+Bob.
+

--- a/roachcase/__init__.py
+++ b/roachcase/__init__.py
@@ -15,6 +15,12 @@ def add_player(player: str) -> None:
     _controller.add_player(player)
 
 
+def remove_player(player: str) -> None:
+    """Remove a player from the roachcase"""
+    print("testing")
+    _controller.remove_player(player)
+
+
 def set_persistence(
     persistence: str = "memory", path: Optional[Union[str, pathlib.Path]] = None
 ) -> None:

--- a/roachcase/__init__.py
+++ b/roachcase/__init__.py
@@ -17,7 +17,6 @@ def add_player(player: str) -> None:
 
 def remove_player(player: str) -> None:
     """Remove a player from the roachcase"""
-    print("testing")
     _controller.remove_player(player)
 
 

--- a/roachcase/_controller.py
+++ b/roachcase/_controller.py
@@ -24,6 +24,13 @@ def add_player(player: str) -> None:
     use_case.add_player(player)
 
 
+def remove_player(player: str) -> None:
+    """Remove a player to the roachcase"""
+    factory = get_use_case_factory()
+    use_case = factory.build_manage_players()
+    use_case.remove_player(player)
+
+
 def set_persistence(
     persistence: str = "memory", path: Optional[Union[str, pathlib.Path]] = None
 ) -> None:

--- a/roachcase/_infrastructure/dynamodb_repositories.py
+++ b/roachcase/_infrastructure/dynamodb_repositories.py
@@ -41,6 +41,13 @@ class DynamoDBGateway:
             waiter = self.__client.get_waiter("table_exists")
             waiter.wait(TableName=table_name)
 
+    def remove(self, table_name: str, item: Dict[str, Any]) -> None:
+        """Add an item to a table"""
+        try:
+            self.__client.delete_item(TableName=table_name, Key=item)
+        except botocore.exceptions.ClientError as error:
+            self.__handle_error(error)
+
     def add(self, table_name: str, item: Dict[str, Any]) -> None:
         """Add an item to a table"""
         try:

--- a/roachcase/_infrastructure/shelf_repositories.py
+++ b/roachcase/_infrastructure/shelf_repositories.py
@@ -31,6 +31,13 @@ class ShelfPlayerRepository(_repositories.PlayerRepository):
                 result = db["players"]
         return result
 
+    def remove(self, player: _entities.Player) -> None:
+        """Get players from the repository"""
+        with shelve.open(self.__db_file) as db:
+            db["players"] = list(
+                filter(lambda existing_player: existing_player != player, db["players"])
+            )
+
 
 class ShelfRepositoryFactory(_repositories.RepositoryFactory):
     def __init__(self, db_file: pathlib.Path):

--- a/roachcase/_repositories.py
+++ b/roachcase/_repositories.py
@@ -14,6 +14,10 @@ class PlayerRepository(abc.ABC):
         """Add a player to the repository"""
 
     @abc.abstractmethod
+    def remove(self, player: _entities.Player) -> None:
+        """Get players from the repository"""
+
+    @abc.abstractmethod
     def get(self) -> Iterable[_entities.Player]:
         """Get players from the repository"""
 
@@ -33,6 +37,12 @@ class InMemoryPlayerRepository(PlayerRepository):
         if player.get_name() in names:
             raise PlayerAlreadyExistError()
         self.__store.append(player)
+
+    def remove(self, player: _entities.Player) -> None:
+        filtered = filter(
+            lambda existing_player: existing_player != player, self.__store
+        )
+        self.__store = list(filtered)
 
     def get(self) -> Iterable[_entities.Player]:
         return iter(self.__store)

--- a/roachcase/_usecases/manage_players.py
+++ b/roachcase/_usecases/manage_players.py
@@ -13,3 +13,7 @@ class ManagePlayerUseCase:
     def add_player(self, name: str) -> None:
         player = _entities.Player(name)
         self.__player_repo.add(player)
+
+    def remove_player(self, name: str) -> None:
+        player = _entities.Player(name)
+        self.__player_repo.remove(player)

--- a/tests/infrastructure/test_dynamodb_repositories.py
+++ b/tests/infrastructure/test_dynamodb_repositories.py
@@ -84,3 +84,9 @@ class TestDynamoDBPlayerRepository(test_repositories.TestInMemoryPlayerRepositor
     @pytest.mark.livedb
     def test_adding_player_with_same_name_raises(self, john, repo):
         super().test_adding_player_with_same_name_raises(john, repo)
+        super().test_add_get_item_on_empty_table(gateway)
+
+    @pytest.mark.slow
+    @pytest.mark.livedb
+    def test_add_remove_item_on_empty_table(self, gateway):
+        super().test_add_remove_item(gateway)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,11 @@ import pytest
 import roachcase
 
 
+@pytest.fixture
+def clear_memory(autouse=True):
+    roachcase.set_persistence("memory")
+
+
 def test_set_persistence():
     observed = roachcase.list_players()
     assert observed == []
@@ -12,13 +17,6 @@ def test_set_persistence():
     roachcase.set_persistence("memory")
     observed = roachcase.list_players()
     assert observed == []
-
-
-@pytest.fixture
-def mem_persistance():
-    roachcase.set_persistence("memory")
-    yield
-    roachcase.set_persistence("memory")
 
 
 class TestPlayerManagement:
@@ -37,8 +35,7 @@ class TestPlayerManagement:
         observed = roachcase.list_players()
         assert set(observed) == set(["Bob"])
 
-    @pytest.mark.usefixtures("mem_persistance")
-    def test_management(self):
+    def test_player_management(self):
         self.check_empty_list_players()
         self.check_add_players()
         self.check_remove_players()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,14 +14,31 @@ def test_set_persistence():
     assert observed == []
 
 
-def test_add_list_players():
+@pytest.fixture
+def mem_persistance():
     roachcase.set_persistence("memory")
-    observed = roachcase.list_players()
-    assert observed == []
-    roachcase.add_player("Bob")
-    roachcase.add_player("Alice")
-    observed = roachcase.list_players()
-    assert set(observed) == set(["Alice", "Bob"])
+    yield
     roachcase.set_persistence("memory")
-    observed = roachcase.list_players()
-    assert observed == []
+
+
+class TestPlayerManagement:
+    def check_empty_list_players(self):
+        observed = roachcase.list_players()
+        assert observed == []
+
+    def check_add_players(self):
+        roachcase.add_player("Bob")
+        roachcase.add_player("Alice")
+        observed = roachcase.list_players()
+        assert set(observed) == set(["Alice", "Bob"])
+
+    def check_remove_players(self):
+        roachcase.remove_player("Alice")
+        observed = roachcase.list_players()
+        assert set(observed) == set(["Bob"])
+
+    @pytest.mark.usefixtures("mem_persistance")
+    def test_management(self):
+        self.check_empty_list_players()
+        self.check_add_players()
+        self.check_remove_players()

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -27,3 +27,8 @@ class TestInMemoryPlayerRepository:
         another_player_named_john = _entities.Player("John")
         with pytest.raises(_repositories.PlayerAlreadyExistError):
             repo.add(another_player_named_john)
+
+    def test_add_remove_item(self, john, repo):
+        repo.add(john)
+        repo.remove(john)
+        assert list(repo.get()) == []

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -16,6 +16,10 @@ class TestInMemoryPlayerRepository:
         expected = [john]
         assert list(observed) == expected
 
+        repo.remove(john)
+        observed = repo.get()
+        assert list(observed) == []
+
     def test_adding_player_with_same_name_raises(self, john, repo):
         repo.add(john)
         with pytest.raises(_repositories.PlayerAlreadyExistError):


### PR DESCRIPTION
Resolves https://github.com/stefanoberri/roachcase/issues/19

This pr adds the ability for the user to remove a player by name from the roachcase.

At present no errors are raised if a user with that name does not exist. This can be dealt with in another PR.

Tests have been added and are passing, but unfortunately the DynamoDB test is running on make test despite being marked as a livedb test. Perhaps you can spot what i am doing wrong here.